### PR TITLE
Add cluster support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ redis-statsd /path/to/config/files/
     "host": "my.redis.host",
     "port": 6379,                  // default: 6379
     "password": "foobar",          // optional,
+    "cluster": false,              // optional (default false)
+    "nodeNames": "prefix",         // optional "tag" or "prefix" (default "prefix"),
     "prefix": "foo.bar.redis.yay", // optional,
     "tags": {                      // optional, tags are supported by the influxdb backend
       "foo": "bar"
@@ -75,3 +77,18 @@ redis-statsd /path/to/config/files/
 
 ####Computed fields
 - percent_used (calculated from used_memory and maxmemory, where available)
+
+###Redis Cluster support
+This module supports redis clustering out-of-the-box. The two relevant configuration options are:
+
+`cluster` - values: `true` or `false`
+
+Tells the redis driver to treat the given server as part of a cluster.
+
+When clustering is turned on, the INFO command is sent to all members and the stats are logged per-cluster member.
+
+`nodeNames` - values: `"tag"` or `"prefix"`
+
+Defines whether you want the node-name (`cluster_myself_name`) to be part of the measurement name ('prefix') or appended as a tag (`tag`). Tags are only supported by the statsd influxdb backend. If you are unsure, leave this parameter unset.
+
+__Note__: The `nodeNames` parameter is ignored when `cluster = false`

--- a/index.js
+++ b/index.js
@@ -1,12 +1,13 @@
 'use strict';
 
-var path = require('path');
-var util = require('util');
-var infoParser = require('./lib/info-parser');
-var redisClientFactory = require('./lib/redis-client-factory');
+const path = require('path');
+const util = require('util');
+const infoParser = require('./lib/info-parser');
+const redisClientFactory = require('./lib/redis-client-factory');
+const libUtils = require('./lib/utils');
 var configDir = path.resolve(process.argv[2] || './');
 
-var StatsD = require('statsd-client');
+const StatsD = require('statsd-client');
 
 util.log('starting...');
 util.log(`using config from ${configDir}`);
@@ -14,37 +15,25 @@ util.log(`using config from ${configDir}`);
 var statsConfig = require(path.join(configDir, 'statsd'));
 var statsdClient = new StatsD({ host: statsConfig.host, port: statsConfig.port, debug: statsConfig.debug });
 
-var getSuffix = function(tags){
-  var suffix = '';
-  if(tags.length > 0){
-    suffix = `,${tags}`;
-  }
-  return suffix;
-};
-
-var getPrefix = function(prefix){
-  var pre = '';
-  if(prefix && prefix.length > 0){
-    pre = `${prefix}.`;
-  }
-  return pre;
-};
-
 var redisClients = require(path.join(configDir, 'redis')).map(redisClientFactory);
 
-redisClients.forEach(function(c){
-  setInterval(function(){
-    c.info(function(err, res){
+redisClients.forEach((c) => {
+  setInterval(() => {
+    var action = c.isCluster ? 'clusterInfo' : 'info';
+
+    c[action]((err, res) => {
       if(err) {
         util.log(`[${c.host}] ${err}`);
         return;
       }
 
-      var prefix = getPrefix(c.prefix);
-      var suffix = getSuffix(c.tags);
+      infoParser(res).forEach((shard) => {
+        var prefix = libUtils.getPrefix(c, shard.name);
+        var suffix = libUtils.getSuffix(c, shard.name);
 
-      infoParser(res).forEach(function(k){
-        statsdClient.gauge(`${prefix}${k[0]}${suffix}`, k[1]);
+        Object.keys(shard.stats).forEach((k) => {
+          statsdClient.gauge(`${prefix}${k}${suffix}`, shard.stats[k]);
+        });
       });
     });
   }, (statsConfig.interval || 10) * 1000);

--- a/lib/computed-fields.js
+++ b/lib/computed-fields.js
@@ -10,32 +10,24 @@ var fields = [
   }
 ];
 
-var findKey = (it, k) => {
-  for(var i = 0; i < it.length; i++){
-    if(it[i] && it[i][0] === k && it[i][1] !== undefined && !isNaN(it[i][1])){
-      return it[i];
-    }
-  }
-};
-
 var computeField = (stats, op) => {
   var values = op.keys.map((k) => {
-    return findKey(stats, k);
+    return stats[k];
   });
 
   if(values.filter((v) => { return v; }).length !== op.keys.length){
     return;
   }
 
-  values = values.map((v) => {
-    return v[1];
-  });
+  stats[op.name] = op.fn.call(null, values);
 
-  return [op.name, op.fn.call(null, values)];
+  return stats;
 };
 
 module.exports.get = (stats) => {
-  return fields.map((c) => {
-    return computeField(stats, c);
+  fields.forEach((c) => {
+    stats = computeField(stats, c);
   });
+
+  return stats;
 };

--- a/lib/info-parser.js
+++ b/lib/info-parser.js
@@ -2,63 +2,80 @@
 
 const gauges = require('./gauges');
 const computedFields = require('./computed-fields');
+const dbreg =  RegExp(/db\d+/i);
 
-var parseStats = (info) => {
-  return info.split('\r\n').map((f) => {
+var splitLines = (info) => {
+  var res = {};
+
+  info.split('\r\n').forEach((f) => {
     if(!f || f.indexOf('#') > -1){
       return;
     }
     var bits = f.split(':');
 
-    if(bits.length !== 2 || gauges[bits[0]] === undefined){
+    if(bits.length !== 2 || !bits[0] || !bits[1]){
       return;
     }
 
-    return [bits[0], parseInt(bits[1] || 0, 10)];
+    res[bits[0]] = bits[1];
   });
+
+  return res;
+};
+
+var parseStats = (info) => {
+  var res = {};
+  Object.keys(info).forEach((k) => {
+    if(!k || !info[k] || gauges[k] === undefined){
+      return;
+    }
+
+    res[k] = parseInt(info[k] || 0, 10);
+  });
+
+  return res;
 };
 
 // keyspace info is differently organised,
 // so needs to be parsed differently
-var parseKeyspaceInfo = (info) => {
-  var bits = info.split('Keyspace');
+var parseKeyspaceInfo = (info,  stats) => {
 
-  if(bits.length !== 2 || !bits[1]){
-    return [];
-  }
+  var dbs = Object.keys(info).filter((f) => {
+    return f.match(dbreg);
+  });
 
-  var result = [];
-
-  bits[1].split('\r\n').forEach((raw) => {
-    if(!raw){
-      return null;
-    }
-
-    var keys = raw.split(':');
-    var dbName = keys[0];
-    if(keys.length !== 2 && !keys[1]){
-      return null;
-    }
-
-    result = result.concat(keys[1].split(',').map((f) => {
+  dbs.forEach((dbName) => {
+    info[dbName].split(',').forEach((f) => {
       var kv = f.split('=');
       if(kv.length !== 2){
         return null;
       }
 
-      return [`${dbName}.${kv[0]}`, parseInt(kv[1] || 0, 10)];
-    }));
+      stats[`${dbName}.${kv[0]}`] = parseInt(kv[1] || 0, 10);
+    });
   });
 
-  return result;
+  return stats;
 };
 
-module.exports = (info) => {
-  var res = parseStats(info);
-  return res.concat(
-    parseKeyspaceInfo(info),
-    computedFields.get(res)
-  ).filter((f) => {
-    return f !== undefined && !isNaN(f[1]);
+var getShardName = (info) => {
+  return info['cluster_myself_name'].substring(0,7) || 'default';
+};
+
+module.exports = (infos) => {
+  if(!Array.isArray(infos)){
+    infos = [infos];
+  }
+
+  return infos.map((raw) => {
+    var info = splitLines(raw);
+    var stats = parseStats(info);
+    stats = parseKeyspaceInfo(raw, stats);
+    stats = computedFields.get(stats);
+
+    return {
+      name: getShardName(info),
+      stats: stats
+    };
   });
 };

--- a/lib/redis-client-factory.js
+++ b/lib/redis-client-factory.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var Redis = require('ioredis');
-var util = require('util');
+const Redis = require('ioredis');
+const util = require('util');
+const Async = require('async');
 
 var buildTags = (tags) => {
   return Object.keys(tags || {})
@@ -10,26 +11,62 @@ var buildTags = (tags) => {
     }).join(',');
 };
 
-module.exports = (c) => {
-  var cl = new Redis({
-    host: c.host,
-    port: c.port,
-    password: c.password
-  }, {
-    enableOfflineQueue: false
+var clusterInfo = function clusterInfo(cb) {
+  var nodes = this.nodes('all');
+
+  Async.map(nodes, (n, done) => {
+    n.info((err, i) => {
+      return done(err, i);
+    });
+  }, (err, info) => {
+    if(err){
+      return cb(err);
+    }
+
+    return cb(null, info);
   });
+};
+
+module.exports = (c) => {
+  var cl;
+
+  if(c.cluster){
+    cl = new Redis.Cluster([{
+      host: c.host,
+      port: c.port,
+      password: c.password
+    }], {
+      enableOfflineQueue: false,
+      redisOptions: {
+        password: c.password
+      }
+    });
+  }
+  else {
+    cl = new Redis({
+      host: c.host,
+      port: c.port,
+      password: c.password
+    }, {
+      enableOfflineQueue: false
+    });
+  }
 
   cl.on('error', (err) => {
     util.log(`[${c.host}] ${err}`);
   });
 
   cl.on('reconnecting', (data) => {
-    util.log(`[${c.host}] reconnecting (delay: ${data.delay}, attempt: ${data.attempt})`);
+    util.log(data);
+    util.log(`[${c.host}] reconnecting`);
   });
 
   cl.host = c.host;
   cl.tags = buildTags(c.tags);
   cl.prefix = c.prefix;
+  cl.isCluster = c.cluster;
+  cl.nodeNames = c.nodeNames || 'prefix';
+  cl.clusterInfo = clusterInfo.bind(cl);
 
   return cl;
 };

--- a/lib/redis-client-factory.js
+++ b/lib/redis-client-factory.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var redis = require('redis');
+var Redis = require('ioredis');
 var util = require('util');
 
 var buildTags = (tags) => {
@@ -11,10 +11,12 @@ var buildTags = (tags) => {
 };
 
 module.exports = (c) => {
-  var cl = redis.createClient({
+  var cl = new Redis({
     host: c.host,
     port: c.port,
-    'enable_offline_queue': false
+    password: c.password
+  }, {
+    enableOfflineQueue: false
   });
 
   cl.on('error', (err) => {
@@ -29,8 +31,5 @@ module.exports = (c) => {
   cl.tags = buildTags(c.tags);
   cl.prefix = c.prefix;
 
-  if(c.password){
-    cl.auth(c.password);
-  }
   return cl;
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,27 @@
+'use strict';
+
+module.exports.getSuffix = function(c, nodeName){
+  var suffix = '';
+  if(c.tags.length > 0){
+    suffix = `,${c.tags}`;
+  }
+
+  if(c.isCluster && c.nodeNames === 'tag'){
+    suffix = `${suffix},node=${nodeName}`;
+  }
+
+  return suffix;
+};
+
+module.exports.getPrefix = function(c, nodeName){
+  var pre = '';
+  if(c.prefix && c.prefix.length > 0){
+    pre = `${c.prefix}.`;
+  }
+
+  if(c.isCluster && c.nodeNames === 'prefix'){
+    pre = `${pre}${nodeName}.`;
+  }
+
+  return pre;
+};

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/andyroyle/redis-statsd-reporter#readme",
   "dependencies": {
-    "redis": "^2.4.2",
+    "ioredis": "^2.0.1",
     "statsd-client": "^0.2.1"
   },
   "devDependencies": {

--- a/redis.json
+++ b/redis.json
@@ -1,6 +1,8 @@
 [
   {
     "host": "localhost",
-    "prefix": "my.redis.yay"
+    "prefix": "my.redis.yay",
+    "cluster": false,
+    "nodeNames": "prefix"
   }
 ]


### PR DESCRIPTION
redis clustering FTW!

Tell the driver that it's talking to a redis-cluster (`cluster: true`) and it'll auto-discover nodes, run the info command and collate the responses (sending separate measurements per node)

Rewrote significant portions of `redis-client-factory.js` and a complete rewrite of `info-parser.js`